### PR TITLE
Fix sequence dots timeline

### DIFF
--- a/tests/examples/sequences/template.lua
+++ b/tests/examples/sequences/template.lua
@@ -358,7 +358,7 @@ local function wrap_timeline(w, dot)
             gen_vertical_line { dot = dot or false},
             {
                 w,
-                top     = dot and 5 or 0,
+                top     = 0,
                 bottom  = dot and 5 or 0,
                 left    = 0,
                 widget  = wibox.container.margin

--- a/tests/examples/sequences/template.lua
+++ b/tests/examples/sequences/template.lua
@@ -368,6 +368,14 @@ local function wrap_timeline(w, dot)
         }
 end
 
+local function gen_vertical_space(spacing)
+    return wibox.widget {
+        draw   = function() end,
+        fit    = function() return 1, spacing end,
+        widget = wibox.widget.base.make_widget()
+    }
+end
+
 local function gen_label(text)
     return wibox.widget {
             gen_vertical_line {
@@ -663,6 +671,7 @@ local function gen_timeline(args)
     for _, event in ipairs(history) do
         local ret = event.callback()
         if event.event == "event" then
+            l:add(wrap_timeline(gen_vertical_space(5)))
             l:add(wrap_timeline(wibox.widget {
                 markup = "<u><b>"..event.description.."</b></u>",
                 widget = wibox.widget.textbox
@@ -675,11 +684,7 @@ local function gen_timeline(args)
     end
 
     -- Spacing.
-    l:add(wrap_timeline( wibox.widget {
-        draw   = function() end,
-        fit    = function() return 1, 10 end,
-        widget = wibox.widget.base.make_widget()
-    }))
+    l:add(wrap_timeline(gen_vertical_space(10)))
 
     l:add(gen_label("End"))
 


### PR DESCRIPTION
So, here is a little fix I wrote.

Maybe I'm wrong on this but there is a little vertical shift between the dots on the timeline and the associated texts. I think it's better like this.

Here is the same image than the one you used in your PR description for a comparison:
![i](https://user-images.githubusercontent.com/6602958/66147045-4ac70b80-e60e-11e9-800f-b79d27e891d0.png)
