### PR TITLE
Implement inheritance into ldoc.

### DIFF
--- a/docs/common/object.ldoc
+++ b/docs/common/object.ldoc
@@ -3,6 +3,7 @@
 -- @tparam string name The name of the signal.
 -- @tparam function func The callback that should be disconnected.
 -- @method disconnect_signal
+-- @baseclass gears.object
 
 --- Emit a signal.
 --
@@ -11,11 +12,13 @@
 --   function receives the object as first argument and then any extra
 --   arguments that are given to emit_signal().
 -- @method emit_signal
+-- @baseclass gears.object
 
 --- Connect to a signal.
 -- @tparam string name The name of the signal.
 -- @tparam function func The callback to call when the signal is emitted.
 -- @method connect_signal
+-- @baseclass gears.object
 
 --- Connect to a signal weakly.
 --
@@ -28,3 +31,4 @@
 -- @tparam string name The name of the signal.
 -- @tparam function func The callback to call when the signal is emitted.
 -- @method weak_connect_signal
+-- @baseclass gears.object

--- a/docs/common/wibox.ldoc
+++ b/docs/common/wibox.ldoc
@@ -4,6 +4,7 @@
 --
 --  * *property::border_width*
 --
+-- @baseclass wibox
 -- @property border_width
 -- @param integer
 
@@ -29,6 +30,7 @@
 --
 --  * *property::border_color*
 --
+-- @baseclass wibox
 -- @property border_color
 -- @param string
 
@@ -38,6 +40,7 @@
 --
 --  * *property::ontop*
 --
+-- @baseclass wibox
 -- @property ontop
 -- @param boolean
 
@@ -47,6 +50,7 @@
 --
 --  * *property::cursor*
 --
+-- @baseclass wibox
 -- @property cursor
 -- @param string
 -- @see mouse
@@ -57,6 +61,7 @@
 --
 --  * *property::visible*
 --
+-- @baseclass wibox
 -- @property visible
 -- @param boolean
 
@@ -66,6 +71,7 @@
 --
 --  * *property::opacity*
 --
+-- @baseclass wibox
 -- @property opacity
 -- @tparam number opacity (between 0 and 1)
 
@@ -75,6 +81,7 @@
 --
 --  * *property::type*
 --
+-- @baseclass wibox
 -- @property type
 -- @param string
 -- @see client.type
@@ -85,6 +92,7 @@
 --
 --  * *property::x*
 --
+-- @baseclass wibox
 -- @property x
 -- @param integer
 
@@ -94,6 +102,7 @@
 --
 --  * *property::y*
 --
+-- @baseclass wibox
 -- @property y
 -- @param integer
 
@@ -103,6 +112,7 @@
 --
 --  * *property::width*
 --
+-- @baseclass wibox
 -- @property width
 -- @param width
 
@@ -112,11 +122,13 @@
 --
 --  * *property::height*
 --
+-- @baseclass wibox
 -- @property height
 -- @param height
 
 --- The wibox screen.
 --
+-- @baseclass wibox
 -- @property screen
 -- @param screen
 
@@ -126,10 +138,12 @@
 --
 --  * *property::drawable*
 --
+-- @baseclass wibox
 -- @property drawable
 -- @tparam drawable drawable
 
 --- The widget that the `wibox` displays.
+-- @baseclass wibox
 -- @property widget
 -- @param widget
 
@@ -139,6 +153,7 @@
 --
 --  * *property::window*
 --
+-- @baseclass wibox
 -- @property window
 -- @param string
 -- @see client.window
@@ -149,6 +164,7 @@
 --
 --  * *property::shape_bounding*
 --
+-- @baseclass wibox
 -- @property shape_bounding
 -- @param surface._native
 
@@ -158,6 +174,7 @@
 --
 --  * *property::shape_clip*
 --
+-- @baseclass wibox
 -- @property shape_clip
 -- @param surface._native
 
@@ -167,6 +184,7 @@
 --
 --  * *property::shape_input*
 --
+-- @baseclass wibox
 -- @property shape_input
 -- @param surface._native
 
@@ -177,6 +195,7 @@
 --
 --  * *property::shape*
 --
+-- @baseclass wibox
 -- @property shape
 -- @tparam gears.shape shape
 
@@ -192,35 +211,41 @@
 --
 --  * *property::input_passthrough*
 --
+-- @baseclass wibox
 -- @property input_passthrough
 -- @param[opt=false] boolean
 -- @see shape_input
 
 --- Get or set mouse buttons bindings to a wibox.
 --
+-- @baseclass wibox
 -- @param buttons_table A table of buttons objects, or nothing.
 -- @method buttons
 
 --- Get or set wibox geometry. That's the same as accessing or setting the x,
 -- y, width or height properties of a wibox.
 --
+-- @baseclass wibox
 -- @param A table with coordinates to modify.
 -- @return A table with wibox coordinates and geometry.
 -- @method geometry
 
 --- Get or set wibox struts.
 --
+-- @baseclass wibox
 -- @param strut A table with new strut, or nothing
 -- @return The wibox strut in a table.
 -- @method struts
 -- @see client.struts
 
 --- The default background color.
+-- @baseclass wibox
 -- @beautiful beautiful.bg_normal
 -- @param color
 -- @see bg
 
 --- The default foreground (text) color.
+-- @baseclass wibox
 -- @beautiful beautiful.fg_normal
 -- @param color
 -- @see fg
@@ -228,9 +253,11 @@
 --- Set a declarative widget hierarchy description.
 -- See [The declarative layout system](../documentation/03-declarative-layout.md.html)
 -- @param args An array containing the widgets disposition
+-- @baseclass wibox
 -- @method setup
 
 --- The background of the wibox.
+-- @baseclass wibox
 -- @param c The background to use. This must either be a cairo pattern object,
 --   nil or a string that gears.color() understands.
 -- @property bg
@@ -241,12 +268,14 @@
 -- If `image` is a function, it will be called with `(context, cr, width, height)`
 -- as arguments. Any other arguments passed to this method will be appended.
 -- @param image A background image or a function
+-- @baseclass wibox
 -- @property bgimage
 -- @see gears.surface
 
 --- The foreground (text) of the wibox.
 -- @param c The foreground to use. This must either be a cairo pattern object,
 --   nil or a string that gears.color() understands.
+-- @baseclass wibox
 -- @property fg
 -- @param color
 -- @see gears.color
@@ -258,4 +287,5 @@
 -- @treturn table A sorted table of widgets positions. The first element is the biggest
 -- container while the last is the topmost widget. The table contains *x*, *y*,
 -- *width*, *height* and *widget*.
+-- @baseclass wibox
 -- @method find_widgets

--- a/docs/common/widget.ldoc
+++ b/docs/common/widget.ldoc
@@ -7,10 +7,12 @@
 -- @return The parent layout
 -- @return The path between self and widget
 -- @method index
+-- @baseclass wibox.widget
 
 --- Get or set the children elements.
 -- @property children
 -- @tparam table The children
+-- @baseclass wibox.widget
 
 --- Get all direct and indirect children widgets.
 -- This will scan all containers recursively to find widgets
@@ -18,27 +20,33 @@
 -- children, contain (directly or indirectly) itself.
 -- @property all_children
 -- @tparam table The children
+-- @baseclass wibox.widget
 
 --- Set a declarative widget hierarchy description.
 -- See [The declarative layout system](../documentation/03-declarative-layout.md.html)
 -- @param args An array containing the widgets disposition
 -- @method setup
+-- @baseclass wibox.widget
 
 --- Force a widget height.
 -- @property forced_height
 -- @tparam number|nil height The height (`nil` for automatic)
+-- @baseclass wibox.widget
 
 --- Force a widget width.
 -- @property forced_width
 -- @tparam number|nil width The width (`nil` for automatic)
+-- @baseclass wibox.widget
 
 --- The widget opacity (transparency).
 -- @property opacity
 -- @tparam[opt=1] number opacity The opacity (between 0 and 1)
+-- @baseclass wibox.widget
 
 --- The widget visibility.
 -- @property visible
 -- @param boolean
+-- @baseclass wibox.widget
 
 --- The widget buttons.
 --
@@ -47,10 +55,12 @@
 -- @property buttons
 -- @param table
 -- @see awful.button
+-- @baseclass wibox.widget
 
 --- Add a new `awful.button` to this widget.
 -- @tparam awful.button button The button to add.
 -- @function add_button
+-- @baseclass wibox.widget
 
 --- Emit a signal and ensure all parent widgets in the hierarchies also
 -- forward the signal. This is useful to track signals when there is a dynamic
@@ -58,6 +68,7 @@
 -- @tparam string signal_name
 -- @param ... Other arguments
 -- @method emit_signal_recursive
+-- @baseclass wibox.widget
 
 --- When the layout (size) change.
 -- This signal is emitted when the previous results of `:layout()` and `:fit()`
@@ -65,6 +76,7 @@
 -- must return the same result when called with the same arguments.
 -- @signal widget::layout_changed
 -- @see widget::redraw_needed
+-- @baseclass wibox.widget
 
 --- When the widget content changed.
 -- This signal is emitted when the content of the widget changes. The widget will
@@ -72,6 +84,7 @@
 -- `:layout()` and `:fit()` would still return the same results as before.
 -- @signal widget::redraw_needed
 -- @see widget::layout_changed
+-- @baseclass wibox.widget
 
 --- When a mouse button is pressed over the widget.
 -- @signal button::press
@@ -101,6 +114,7 @@
 -- @tparam number find_widgets_result.widget_height The exact height of the widget
 -- in its local coordinate system.
 -- @see mouse
+-- @baseclass wibox.widget
 
 --- When a mouse button is released over the widget.
 -- @signal button::release
@@ -130,6 +144,7 @@
 -- @tparam number find_widgets_result.widget_height The exact height of the widget
 -- in its local coordinate system.
 -- @see mouse
+-- @baseclass wibox.widget
 
 --- When the mouse enter a widget.
 -- @signal mouse::enter
@@ -153,6 +168,7 @@
 -- @tparam number find_widgets_result.widget_height The exact height of the widget
 -- in its local coordinate system.
 -- @see mouse
+-- @baseclass wibox.widget
 
 --- When the mouse leave a widget.
 -- @signal mouse::leave
@@ -176,3 +192,4 @@
 -- @tparam number find_widgets_result.widget_height The exact height of the widget
 -- in its local coordinate system.
 -- @see mouse
+-- @baseclass wibox.widget

--- a/docs/ldoc.css
+++ b/docs/ldoc.css
@@ -288,6 +288,7 @@ table.module_list td.summary, table.function_list td.summary {
     background-color: white;
     width: 100%;
     border-left-width: 0px;
+    border-right: none;
 }
 
 table.function_list td.shortname {
@@ -332,6 +333,19 @@ table.function_list .function_named_args {
     color: #ba97ff;
     text-decoration: underline;
     text-decoration-color: #bbd3ff;
+}
+
+table.function_list td.baseclass {
+    background-color: white;
+    color: #a4c7ff;
+    min-width: 200px;
+    border-left: none;
+    border-right: none;
+    text-align: right;
+}
+
+.baseclass {
+    font-size: 85%;
 }
 
 dl.function {

--- a/docs/ldoc.ltp
+++ b/docs/ldoc.ltp
@@ -151,6 +151,11 @@
       <td class="name" $(nowrap)><a href="#$(item.name)">$(dn)</a></td>
 #   end
       <td class="summary">$(M(item.summary,item))</td>
+      <td class="baseclass" $(nowrap)>
+#   if item.inherited then
+        Inherited from $(item.baseclass)
+#   end
+      </td>
     </tr>
 #  end -- for items
 # last_kind = kind
@@ -196,6 +201,9 @@
     <strong>$(display_name(item))</strong>
 #   if item.display_type then
     <span class="proptype">($(item.display_type))</span>
+#   end
+#   if item.inherited then
+    <span class="baseclass" $(nowrap)>&nbsp;&middot;&nbsp;Inherited from $(item.baseclass)</span>
 #   end
 #   if ldoc.prettify_files and ldoc.is_file_prettified[item.module.file.filename] then
     <a style="float:right;" href="$(ldoc.source_ref(item))">line $(item.lineno)</a>


### PR DESCRIPTION
Hi!

I added the missing part to your PR to match my inheritance documentation goal.

I added the new `@baseclass` tag to the `docs/common/object.ldoc`, `docs/common/widget.ldoc` and `docs/common/wibox.ldoc` files.

Here is what it looks like:
![Screenshot_2019-11-26 Widgetmod wibox widget imagebox - awesome API documentation](https://user-images.githubusercontent.com/6602958/69635322-6ec62c80-1054-11ea-8b67-d422cc7e969a.png)
`wibox.widget.imagebox` "Object properties" table.

![Screenshot_2019-11-26 Containermod wibox container arcchart - awesome API documentation](https://user-images.githubusercontent.com/6602958/69635320-6ec62c80-1054-11ea-9e75-9481261ead12.png)
`wibox.container.arcchart` "Object methods" section. 

![Screenshot_2019-11-26 Popupmod awful wibar - awesome API documentation](https://user-images.githubusercontent.com/6602958/69635321-6ec62c80-1054-11ea-8933-fc028f94ac7b.png)
`awful.wibar` "Theme variables" section.

You should definitly take a look at my css, I took some rules from other components without taking care if colors/text-size/... have their own meaning. 

Also, I tried but couldn't find a way to properly link the "inherited from <module>" to the right module. So I ended up removing link and use text only (which I don't really like but better than a broken/wrong link).

Thanks a lot for your work! It made this implementation a trivial task and much cleaner compared to what I first come with in ~https://github.com/awesomeWM/awesome/pull/2922~ (oops wrong link) https://github.com/awesomeWM/awesome/pull/2921.