### PR TITLE
Add anchor icon to copy direct link

### DIFF
--- a/docs/ldoc.css
+++ b/docs/ldoc.css
@@ -645,3 +645,17 @@ pre .url { color: #272fc2; text-decoration: underline; }
     color: #00000044;
     margin-top: 15px;
 }
+
+.copy-link {
+    font-size: 9px;
+    padding: 2px;
+    border-radius: 9px;
+    vertical-align: middle;
+    text-decoration: none;
+}
+.copy-link--success {
+    background-color: green;
+}
+.copy-link--failure {
+    background-color: red;
+}

--- a/docs/ldoc.ltp
+++ b/docs/ldoc.ltp
@@ -339,7 +339,7 @@
 #  end
 #  for item in iter(k.items) do if not item.tags.hidden then
     <dt>
-    <a name = "$(item.name)"></a>
+    <a class="copy-link js-copy-link" name="$(item.name)" href="#$(item.name)">&#128279;</a>
     <strong>$(display_name(item))</strong>
 #   if item.display_inheritance then
     <span class="inheritance">
@@ -559,6 +559,49 @@
         if (target.classList.contains("open")) {
             target.classList.remove("open");
         }
+    });
+
+    const copyResultClasses = {
+        success : "copy-link--success",
+        failure: "copy-link--failure"
+    };
+
+    const removeCopyResultClasses = ($target) =>
+        Object.values(copyResultClasses).forEach(c => $target.classList.remove(c));
+
+    document.querySelectorAll(".js-copy-link").forEach(copyLink => {
+        copyLink.addEventListener("click", function(e) {
+            e.preventDefault();
+            const $target = e.target;
+
+            removeCopyResultClasses($target);
+
+            let link = $target.href;
+            if (!link) {
+                return;
+            }
+            if (link.startsWith("#")) {
+                const curr = window.location.pathname;
+                link = curr.substring(0, curr.indexOf("#")) + link;
+            }
+
+            // We need to create a fake element to copy the text from
+            const fakeElement = document.createElement("textarea");
+            fakeElement.value = link;
+            document.body.appendChild(fakeElement);
+            fakeElement.select();
+
+            let success = false;
+            try {
+                success = document.execCommand("copy");
+            } catch(err) {
+                success = false;
+            }
+
+            fakeElement.remove();
+            $target.classList.add(success ? copyResultClasses.success : copyResultClasses.failure);
+            setInterval(() => removeCopyResultClasses($target), 1500);
+        });
     });
 </script>
 


### PR DESCRIPTION
Hello,

This is something I'd like to have when helping people online : a quick button to copy the function/property anchor link.

I hope this can be included in the scope of your polishing-the-doc effort.

![2022-01-02-172402_319x227_scrot](https://user-images.githubusercontent.com/6602958/147882272-ff8ebd1d-e072-4205-a266-80fc84150f58.png)


Notes :

- I used the `&#128279;` code to refer to the link icon/emoji. It should work on any browser, but depends on the font/emoji configuration. As an alternative, we could ship our own icon.
- I used `green` and `red` color flashes to express success or failure. I think we should select better variant to these color :shrug: 