### PR TITLE
Add max-size to generated images

### DIFF
--- a/docs/config.ld
+++ b/docs/config.ld
@@ -31,7 +31,9 @@ should be useful for you.
 
 ### Default configuration components name:
 
-<center><img src="images/AUTOGEN_awful_popup_defaultconfig.svg"></center>
+<center>
+    <object class="img-object" data="images/AUTOGEN_awful_popup_defaultconfig.svg" alt="" type="image/svg+xml"></object>
+</center>
 
 ### Guides
 

--- a/docs/ldoc.css
+++ b/docs/ldoc.css
@@ -645,3 +645,8 @@ pre .url { color: #272fc2; text-decoration: underline; }
     color: #00000044;
     margin-top: 15px;
 }
+
+.img-object {
+    max-width: 100%;
+    padding: 5px;
+}

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -237,7 +237,7 @@ function(run_test test_path namespace escaped_content)
         set(OUTPUT_RAW_IMAGE_PATH "${RAW_IMAGE_PATH}.svg")
         set(OUTPUT_IMAGE_PATH "${IMAGE_PATH}.svg")
         escape_string(
-            "<object data=\"../images/AUTOGEN${namespace}_${TEST_FILE_NAME}.svg\" alt=\"Usage example\" type=\"image/svg+xml\"></object>\n"
+            "<object class=\"img-object\" data=\"../images/AUTOGEN${namespace}_${TEST_FILE_NAME}.svg\" alt=\"Usage example\" type=\"image/svg+xml\"></object>\n"
             "${TEST_DOC_CONTENT}" TEST_DOC_CONTENT ""
         )
     else()


### PR DESCRIPTION
Hello,

This is something that annoy me when I do mobile browser. Thanks to this max-width, images no-longer "push" the page bigger than the screen size.

I also started to add `<center>` tags to images in module descriptions. But I'm not so sure whether this is something we want everywhere (e.i. ruled have sequence diagram, so center the image wouldn't look good), and I didn't feel like pushing the change only on some modules is good with a regard on consistence...